### PR TITLE
[codex] remove unlisted from moonbit 0.9 blog

### DIFF
--- a/blog/2026-04-08-moonbit-0-9-release/index.md
+++ b/blog/2026-04-08-moonbit-0-9-release/index.md
@@ -1,5 +1,4 @@
 ---
-unlisted: true
 description: "MoonBit 0.9 introduces formal verification for AI-native workflows, enabling AI systems to generate code that is not just functional, but provably correct."
 slug: moonbit-0-9-release
 image: /img/blogs/2026-04-08-moonbit-0-9-release/cover.png


### PR DESCRIPTION
## Summary
- remove `unlisted: true` from `blog/2026-04-08-moonbit-0-9-release/index.md`
- make the English MoonBit 0.9 release post visible on the website blog list

## Validation
- no build/test run; frontmatter-only change
