### PR TITLE
[codex] fix moonbit 0.9 blog cover path

### DIFF
--- a/blog/2026-04-08-moonbit-0-9-release/index.md
+++ b/blog/2026-04-08-moonbit-0-9-release/index.md
@@ -1,7 +1,7 @@
 ---
 description: "MoonBit 0.9 introduces formal verification for AI-native workflows, enabling AI systems to generate code that is not just functional, but provably correct."
 slug: moonbit-0-9-release
-image: /img/blogs/2026-04-08-moonbit-0-9-release/cover.png
+image: ./cover.png
 tags: [MoonBit, AI]
 ---
 


### PR DESCRIPTION
## Summary
- fix the English MoonBit 0.9 blog cover image path in frontmatter
- change `image: /img/blogs/2026-04-08-moonbit-0-9-release/cover.png` to `image: ./cover.png`
- ensure the blog list card uses the built image asset instead of a missing static path

## Root cause
The previous PR that removed `unlisted` was merged before the follow-up cover-image-path fix landed, so production still referenced the broken `/img/blogs/...` URL.

## Validation
- rebuilt the local preview build
- confirmed the blog list now references `assets/images/cover-...png` for `moonbit-0-9-release`
