### PR TITLE
[codex] refresh 2026 SCC showcase finalists and links

### DIFF
--- a/i18n/zh/docusaurus-plugin-content-pages/2026-scc/showcase/index.tsx
+++ b/i18n/zh/docusaurus-plugin-content-pages/2026-scc/showcase/index.tsx
@@ -15,9 +15,14 @@ export default function Page() {
       <div className={styles.shell}>
         <ContestNavbar activeIndex={1} items={items2026} qqGroup={false} />
         <RabbitaShowcaseMount
+          localeToggleLabel='语言'
+          themeToggleLabel='主题'
+          localeOptions={[
+            { label: '中文', href: '/zh/2026-scc/showcase/', isActive: true },
+            { label: 'English', href: '/2026-scc/showcase/', isActive: false }
+          ]}
           lightModeLabel='白天模式'
           darkModeLabel='夜间模式'
-          toggleLabel='展示墙主题切换'
         />
       </div>
     </ContestLayout>

--- a/src/components/ContestNavbar/index.tsx
+++ b/src/components/ContestNavbar/index.tsx
@@ -81,7 +81,7 @@ export const items2026en: ContestNavbarItem[] = [
 
 export default function ContestNavbar({
   activeIndex,
-  items,
+  items = [],
   qqGroup = false,
   buttons
 }: {

--- a/src/components/RabbitaShowcaseMount/index.tsx
+++ b/src/components/RabbitaShowcaseMount/index.tsx
@@ -10,15 +10,23 @@ const scriptSrc = '/rabbita-2026-scc-showcase/main.js'
 const styleHref = '/rabbita-2026-scc-showcase/styles.css'
 
 type Props = {
+  localeToggleLabel: string
+  themeToggleLabel: string
+  localeOptions: Array<{
+    label: string
+    href: string
+    isActive: boolean
+  }>
   lightModeLabel: string
   darkModeLabel: string
-  toggleLabel: string
 }
 
 export default function RabbitaShowcaseMount({
-  lightModeLabel,
-  darkModeLabel,
-  toggleLabel
+  localeToggleLabel = 'Language',
+  themeToggleLabel = 'Theme',
+  localeOptions = [],
+  lightModeLabel = 'Light',
+  darkModeLabel = 'Dark'
 }: Props) {
   const { colorMode, setColorMode } = useColorMode()
 
@@ -63,29 +71,53 @@ export default function RabbitaShowcaseMount({
   return (
     <>
       <div className={styles.toolbar}>
-        <div className={styles.modeSwitch} role='group' aria-label={toggleLabel}>
-          <button
-            type='button'
-            className={clsx(
-              styles.modeButton,
-              colorMode !== 'dark' && styles.modeButtonActive
-            )}
-            onClick={() => setColorMode('light')}
-            aria-pressed={colorMode !== 'dark'}
-          >
-            {lightModeLabel}
-          </button>
-          <button
-            type='button'
-            className={clsx(
-              styles.modeButton,
-              colorMode === 'dark' && styles.modeButtonActive
-            )}
-            onClick={() => setColorMode('dark')}
-            aria-pressed={colorMode === 'dark'}
-          >
-            {darkModeLabel}
-          </button>
+        <div className={styles.switchCluster}>
+          <div className={styles.switchGroup}>
+            <div className={styles.switchLabel}>{localeToggleLabel}</div>
+            <div className={styles.localeSwitch} role='group' aria-label={localeToggleLabel}>
+              {localeOptions.map((option) => (
+                <a
+                  key={option.href}
+                  href={option.href}
+                  className={clsx(
+                    styles.modeButton,
+                    styles.localeButton,
+                    option.isActive && styles.modeButtonActive
+                  )}
+                  aria-current={option.isActive ? 'page' : undefined}
+                >
+                  {option.label}
+                </a>
+              ))}
+            </div>
+          </div>
+          <div className={styles.switchGroup}>
+            <div className={styles.switchLabel}>{themeToggleLabel}</div>
+            <div className={styles.modeSwitch} role='group' aria-label={themeToggleLabel}>
+              <button
+                type='button'
+                className={clsx(
+                  styles.modeButton,
+                  colorMode !== 'dark' && styles.modeButtonActive
+                )}
+                onClick={() => setColorMode('light')}
+                aria-pressed={colorMode !== 'dark'}
+              >
+                {lightModeLabel}
+              </button>
+              <button
+                type='button'
+                className={clsx(
+                  styles.modeButton,
+                  colorMode === 'dark' && styles.modeButtonActive
+                )}
+                onClick={() => setColorMode('dark')}
+                aria-pressed={colorMode === 'dark'}
+              >
+                {darkModeLabel}
+              </button>
+            </div>
+          </div>
         </div>
       </div>
       <div id={mountId} />

--- a/src/pages/2026-scc/showcase/index.tsx
+++ b/src/pages/2026-scc/showcase/index.tsx
@@ -14,9 +14,14 @@ export default function Page() {
       <div className={styles.shell}>
         <ContestNavbar activeIndex={1} items={items2026en} qqGroup={false} />
         <RabbitaShowcaseMount
+          localeToggleLabel='Language'
+          themeToggleLabel='Theme'
+          localeOptions={[
+            { label: '中文', href: '/zh/2026-scc/showcase/', isActive: false },
+            { label: 'English', href: '/2026-scc/showcase/', isActive: true }
+          ]}
           lightModeLabel='Light Mode'
           darkModeLabel='Dark Mode'
-          toggleLabel='Showcase theme switch'
         />
       </div>
     </ContestLayout>

--- a/src/pages/2026-scc/showcase/wrapper.module.css
+++ b/src/pages/2026-scc/showcase/wrapper.module.css
@@ -10,7 +10,30 @@
   margin-bottom: 1rem;
 }
 
-.modeSwitch {
+.switchCluster {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  width: 100%;
+}
+
+.switchGroup {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.switchLabel {
+  padding-left: 0.2rem;
+  color: #66758d;
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.modeSwitch,
+.localeSwitch {
   display: inline-flex;
   gap: 0.35rem;
   padding: 0.3rem;
@@ -20,7 +43,14 @@
   box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
 }
 
+.modeSwitch {
+  justify-content: flex-end;
+}
+
 .modeButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   border: 0;
   padding: 0.65rem 1rem;
   border-radius: 999px;
@@ -32,13 +62,22 @@
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.localeButton {
+  text-decoration: none;
+}
+
 .modeButtonActive {
   color: #fff;
   background: linear-gradient(135deg, #d1288f, #b92482);
   box-shadow: 0 10px 24px rgba(185, 36, 130, 0.24);
 }
 
-:global([data-theme='dark']) .modeSwitch {
+:global([data-theme='dark']) .switchLabel {
+  color: #9caabd;
+}
+
+:global([data-theme='dark']) .modeSwitch,
+:global([data-theme='dark']) .localeSwitch {
   border-color: rgba(224, 64, 176, 0.22);
   background: rgba(16, 22, 34, 0.86);
   box-shadow: 0 16px 34px rgba(0, 0, 0, 0.26);
@@ -64,7 +103,13 @@
     justify-content: center;
   }
 
-  .modeSwitch {
+  .switchCluster {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .modeSwitch,
+  .localeSwitch {
     width: 100%;
     justify-content: center;
   }

--- a/src/rabbita/2026-scc-showcase/main/main.mbt
+++ b/src/rabbita/2026-scc-showcase/main/main.mbt
@@ -108,8 +108,8 @@ fn hero_title() -> String {
 ///|
 fn hero_intro() -> String {
   lang(
-    zh="截至 2026 年 4 月 7 日，这一版集中展示当前已经正式启动、并且已经公开 GitHub 仓库的参赛项目。",
-    en="As of April 7, 2026, this edition focuses on projects that have officially kicked off and already expose a public GitHub repository.",
+    zh="截至 2026 年 4 月 21 日，这一版集中展示当前已经正式启动、并且已经公开 GitHub 仓库的 \{featured_project_count()} 个参赛项目。",
+    en="As of April 21, 2026, this edition focuses on \{featured_project_count()} projects that have officially kicked off and already expose a public GitHub repository.",
   )
 }
 
@@ -160,10 +160,18 @@ fn card_badge() -> String {
 }
 
 ///|
+fn featured_project_count() -> Int {
+  contest_cards().length() + reference_cards().length()
+}
+
+///|
 fn contest_signals() -> Array[Signal] {
   [
     {
-      value: lang(zh="19 个项目", en="19 Projects"),
+      value: lang(
+        zh="\{featured_project_count()} 个项目",
+        en="\{featured_project_count()} Projects",
+      ),
       label: lang(zh="当前已正式启动并已收录展示", en="Officially started and already featured here"),
     },
     {
@@ -175,7 +183,7 @@ fn contest_signals() -> Array[Signal] {
       label: lang(zh="这些项目都已进入公开开发阶段", en="Each listed project is already being built in the open"),
     },
     {
-      value: lang(zh="2026 年 4 月 7 日", en="April 7, 2026"),
+      value: lang(zh="2026 年 4 月 21 日", en="April 21, 2026"),
       label: lang(zh="当前整理日期", en="Current curation date"),
     },
   ]
@@ -580,7 +588,41 @@ fn reference_cards() -> Array[Card] {
         { label: lang(zh="公开分支", en="Public Branch"), url: "https://github.com/MrsFlower/MoonPalace/tree/windows-build-setup", external: true },
       ],
     },
+    backfill_card("MoonMarkMind", "https://github.com/Xiao-li-He/MoonMarkMind"),
+    backfill_card("MoonParse", "https://github.com/caiklonghuan/MoonParse"),
+    backfill_card("yuecharts", "https://github.com/OverflowCat/yuecharts"),
+    backfill_card("FlowLabLite", "https://github.com/YuFenfen-ai/FlowLabLite"),
+    backfill_card("MoonForge", "https://github.com/helloLeila/MoonForge"),
+    backfill_card("moonink", "https://github.com/Kozmosa/moonink"),
+    backfill_card("magpiedb", "https://github.com/codeworm96/magpiedb"),
+    backfill_card("mengxi", "https://github.com/MaoDingA/mengxi"),
+    backfill_card("MetaEditor", "https://github.com/ch3coohlink/MetaEditor"),
+    backfill_card("cogna", "https://github.com/cogna-dev/cogna"),
+    backfill_card("AstrClaw", "https://github.com/EinoPlasma/AstrClaw/blob/master/README.md"),
   ]
+}
+
+///|
+fn backfill_card(title : String, url : String) -> Card {
+  {
+    badge: card_badge(),
+    stage: lang(zh="公开仓库", en="Public Repo"),
+    category: lang(zh="待补简介", en="Profile Pending"),
+    title,
+    subtitle: lang(zh="已补充到展示墙的参赛项目仓库", en="Contest repository added to the showcase"),
+    desc: lang(zh="该项目链接已补充到展示页，后续可以继续补充更完整的项目介绍、亮点和演示信息。", en="This project link has been added to the showcase. A fuller project profile, highlights, and demo links can be added later."),
+    fallback: title,
+    cover: "",
+    highlights: [
+      lang(zh="公开 GitHub 页面已接入展示墙", en="Public GitHub page is now linked from the showcase"),
+      lang(zh="可直接查看 README、源码与提交记录", en="Open README, source code, and commit history directly"),
+      lang(zh="后续可继续补充 Demo 与项目说明", en="Demo links and project details can be added later"),
+    ],
+    tags: ["MoonBit", "GitHub", lang(zh="公开项目", en="Open Project")],
+    links: [
+      { label: lang(zh="GitHub 页面", en="GitHub Page"), url, external: true },
+    ],
+  }
 }
 
 ///|

--- a/src/rabbita/2026-scc-showcase/main/main.mbt
+++ b/src/rabbita/2026-scc-showcase/main/main.mbt
@@ -171,8 +171,8 @@ fn label_finalists() -> String {
 ///|
 fn title_finalists() -> String {
   lang(
-    zh="以下 10 个项目按赛事海报公布顺序整理，作为本次大型软件合成挑战赛当前正式公布的初赛入围名单。完整展示墙仍保留全部公开参赛项目。",
-    en="The 10 projects below follow the organizer's published finalist poster order and represent the currently announced preliminary-round finalists. The full showcase below still keeps the broader public project roster.",
+    zh="以下 10 个项目按赛事海报公布顺序整理，作为本次大型软件合成挑战赛当前正式公布的初赛入围名单。",
+    en="The 10 projects below follow the organizer's published finalist poster order and represent the currently announced preliminary-round finalists.",
   )
 }
 

--- a/src/rabbita/2026-scc-showcase/main/main.mbt
+++ b/src/rabbita/2026-scc-showcase/main/main.mbt
@@ -286,7 +286,7 @@ fn finalist_projects() -> Array[FinalistProject] {
     },
     {
       rank: "7",
-      title: "markitdown",
+      title: "MoonBitMark",
       repo_text: "github.com/hnlyxiaobing/MoonBitMark",
       repo_url: "https://github.com/hnlyxiaobing/MoonBitMark",
       desc: lang(

--- a/src/rabbita/2026-scc-showcase/main/main.mbt
+++ b/src/rabbita/2026-scc-showcase/main/main.mbt
@@ -736,7 +736,7 @@ fn reference_cards() -> Array[Card] {
     backfill_card("mengxi", "https://github.com/MaoDingA/mengxi"),
     backfill_card("MetaEditor", "https://github.com/ch3coohlink/MetaEditor"),
     backfill_card("cogna", "https://github.com/cogna-dev/cogna"),
-    backfill_card("AstrClaw", "https://github.com/EinoPlasma/AstrClaw/blob/master/README.md"),
+    backfill_card("AstrClaw", "https://github.com/EinoPlasma/AstrClaw"),
   ]
 }
 

--- a/src/rabbita/2026-scc-showcase/main/main.mbt
+++ b/src/rabbita/2026-scc-showcase/main/main.mbt
@@ -83,6 +83,15 @@ struct Card {
 }
 
 ///|
+struct FinalistProject {
+  rank : String
+  title : String
+  repo_text : String
+  repo_url : String
+  desc : String
+}
+
+///|
 struct Step {
   title : String
   desc : String
@@ -155,6 +164,29 @@ fn label_checklist() -> String {
 }
 
 ///|
+fn label_finalists() -> String {
+  lang(zh="初赛入围项目", en="Preliminary Finalists")
+}
+
+///|
+fn title_finalists() -> String {
+  lang(
+    zh="以下 10 个项目按赛事海报公布顺序整理，作为本次大型软件合成挑战赛当前正式公布的初赛入围名单。完整展示墙仍保留全部公开参赛项目。",
+    en="The 10 projects below follow the organizer's published finalist poster order and represent the currently announced preliminary-round finalists. The full showcase below still keeps the broader public project roster.",
+  )
+}
+
+///|
+fn finalist_project_label() -> String {
+  lang(zh="项目名", en="Project")
+}
+
+///|
+fn finalist_desc_label() -> String {
+  lang(zh="项目介绍", en="Project Summary")
+}
+
+///|
 fn card_badge() -> String {
   lang(zh="已正式启动", en="Officially Started")
 }
@@ -185,6 +217,112 @@ fn contest_signals() -> Array[Signal] {
     {
       value: lang(zh="2026 年 4 月 21 日", en="April 21, 2026"),
       label: lang(zh="当前整理日期", en="Current curation date"),
+    },
+  ]
+}
+
+///|
+fn finalist_projects() -> Array[FinalistProject] {
+  [
+    {
+      rank: "1",
+      title: "Moon Lottie",
+      repo_text: "github.com/cg-zhou/moon-lottie",
+      repo_url: "https://github.com/cg-zhou/moon-lottie",
+      desc: lang(
+        zh="基于 MoonBit 的 Lottie 动画播放与集成项目，可结合 npm 分发、React 使用，具备完整构建流程。",
+        en="A MoonBit-based Lottie playback and integration project designed to work with npm distribution and React usage, with a complete build pipeline already in place.",
+      ),
+    },
+    {
+      rank: "2",
+      title: lang(zh="定理证明器移植", en="Theorem Prover Port"),
+      repo_text: "github.com/Luna-Flow/QED",
+      repo_url: "https://github.com/Luna-Flow/QED",
+      desc: lang(
+        zh="将定理证明器移植到 MoonBit，包含较完整的 kernel、logic、parser、tactics、prover 与命令行工具链。",
+        en="Ports a theorem prover to MoonBit, covering a relatively complete kernel, logic, parser, tactics, prover, and command-line toolchain.",
+      ),
+    },
+    {
+      rank: "3",
+      title: "moon-bash",
+      repo_text: "github.com/Haoxincode/MoonBash",
+      repo_url: "https://github.com/Haoxincode/MoonBash",
+      desc: lang(
+        zh="用 MoonBit 实现的 Bash / 类 Shell 项目，提供浏览器演示，覆盖解析、执行与前端展示。",
+        en="A Bash-like shell project implemented in MoonBit, with a browser demo that already covers parsing, execution, and frontend presentation.",
+      ),
+    },
+    {
+      rank: "4",
+      title: "MoonMarkMind",
+      repo_text: "github.com/Xiao-li-He/MoonMarkMind",
+      repo_url: "https://github.com/Xiao-li-He/MoonMarkMind",
+      desc: lang(
+        zh="基于 MoonBit 的 Markdown 脑图可视化编辑工具，支持图形化交互与网页展示。",
+        en="A MoonBit Markdown mind-map visualization editor that supports graphical interaction and web presentation.",
+      ),
+    },
+    {
+      rank: "5",
+      title: "morm",
+      repo_text: "github.com/oboard/morm",
+      repo_url: "https://github.com/oboard/morm",
+      desc: lang(
+        zh="面向数据库访问场景的轻量 ORM 与 SQL 生成工具，侧重 schema 建模与查询生成。",
+        en="A lightweight ORM and SQL generation tool for database access scenarios, focused on schema modeling and query generation.",
+      ),
+    },
+    {
+      rank: "6",
+      title: "MoonParse",
+      repo_text: "github.com/caiklonghuan/MoonParse",
+      repo_url: "https://github.com/caiklonghuan/MoonParse",
+      desc: lang(
+        zh="用 MoonBit 实现的解析工具 / 解析框架，包含 grammar、runtime 与相关解析能力。",
+        en="A parser toolchain and parsing framework built in MoonBit, including grammar, runtime, and related parsing capabilities.",
+      ),
+    },
+    {
+      rank: "7",
+      title: "markitdown",
+      repo_text: "github.com/hnlyxiaobing/MoonBitMark",
+      repo_url: "https://github.com/hnlyxiaobing/MoonBitMark",
+      desc: lang(
+        zh="基于 MoonBit 的 Markdown 处理工具，支持一定的文档转换与 MCP 相关能力。",
+        en="A MoonBit-based Markdown processing tool with document conversion support and MCP-related capabilities.",
+      ),
+    },
+    {
+      rank: "8",
+      title: lang(zh="视觉小说引擎项目", en="Visual Novel Engine"),
+      repo_text: "github.com/zvmsbackend/reisen",
+      repo_url: "https://github.com/zvmsbackend/reisen",
+      desc: lang(
+        zh="基于 MoonBit 的视觉小说引擎，提供网页预览与模板，可用于构建互动叙事内容。",
+        en="A MoonBit visual novel engine with web preview and templates, suitable for building interactive narrative content.",
+      ),
+    },
+    {
+      rank: "9",
+      title: lang(zh="Quiver 移植", en="Quiver Port"),
+      repo_text: "github.com/kokic/kwiver",
+      repo_url: "https://github.com/kokic/kwiver",
+      desc: lang(
+        zh="将 Quiver 类工具移植到 MoonBit，包含可运行的构建、测试与浏览器端界面。",
+        en="Ports a Quiver-style tool to MoonBit, including runnable build scripts, tests, and a browser-side interface.",
+      ),
+    },
+    {
+      rank: "10",
+      title: "MoonECAT",
+      repo_text: "github.com/Afate2023/MoonECAT",
+      repo_url: "https://github.com/Afate2023/MoonECAT",
+      desc: lang(
+        zh="基于 MoonBit 的 EtherCAT 相关项目，面向工业通信场景，包含场景分析与 trace 分析能力。",
+        en="A MoonBit EtherCAT project aimed at industrial communication scenarios, including scene analysis and trace analysis capabilities.",
+      ),
     },
   ]
 }
@@ -672,6 +810,25 @@ fn view_signal(signal : Signal) -> Html {
 }
 
 ///|
+fn view_finalist(finalist : FinalistProject) -> Html {
+  div(class="rsc-finalist-row", [
+    div(class="rsc-finalist-project", [
+      div(class="rsc-finalist-title-row", [
+        span(class="rsc-finalist-rank", finalist.rank),
+        h3(class="rsc-finalist-title", finalist.title),
+      ]),
+      a(
+        class="rsc-finalist-repo",
+        href=finalist.repo_url,
+        target=Blank,
+        finalist.repo_text,
+      ),
+    ]),
+    p(class="rsc-finalist-desc", finalist.desc),
+  ])
+}
+
+///|
 fn view_card(card : Card) -> Html {
   ignore(card.badge)
   ignore(card.cover)
@@ -756,6 +913,26 @@ fn view_section(label : String, title : String, cards : Array[Card]) -> Html {
 }
 
 ///|
+fn view_finalists() -> Html {
+  section(class="rsc-section", [
+    div(class="rsc-section-head", [
+      p(class="rsc-section-label", label_finalists()),
+      h2(class="rsc-section-title rsc-section-title--subtle", title_finalists()),
+    ]),
+    div(class="rsc-finalist-board", [
+      div(class="rsc-finalist-head", [
+        span(class="rsc-finalist-head-cell", finalist_project_label()),
+        span(class="rsc-finalist-head-cell", finalist_desc_label()),
+      ]),
+      div(
+        class="rsc-finalist-list",
+        finalist_projects().map(fn(finalist) { view_finalist(finalist) }),
+      ),
+    ]),
+  ])
+}
+
+///|
 fn view_hero() -> Html {
   section(class="rsc-hero", [
     div(class="rsc-hero-copy", [
@@ -790,6 +967,7 @@ fn view(dispatch : Dispatch[Msg], model : Model) -> Html {
   let approved_cards = contest_cards() + reference_cards()
   div(class="rsc-page", [
     view_hero(),
+    view_finalists(),
     view_section(label_slots(), title_slots(), approved_cards),
     view_steps(),
   ])

--- a/src/rabbita/2026-scc-showcase/styles.css
+++ b/src/rabbita/2026-scc-showcase/styles.css
@@ -49,6 +49,21 @@
     0 20px 40px rgba(4, 10, 28, 0.18);
   --rsc-signal-label: rgba(247, 251, 255, 0.84);
   --rsc-gridline: rgba(255, 255, 255, 0.045);
+  --rsc-finalist-surface:
+    radial-gradient(circle at top right, rgba(209, 40, 143, 0.14), transparent 24%),
+    radial-gradient(circle at bottom left, rgba(101, 79, 240, 0.12), transparent 24%),
+    linear-gradient(180deg, rgba(10, 20, 49, 0.98), rgba(6, 13, 34, 0.98));
+  --rsc-finalist-border: rgba(128, 151, 220, 0.18);
+  --rsc-finalist-rule: rgba(216, 227, 255, 0.12);
+  --rsc-finalist-title: #f7fbff;
+  --rsc-finalist-text: rgba(239, 245, 255, 0.92);
+  --rsc-finalist-muted: rgba(219, 230, 247, 0.72);
+  --rsc-finalist-rank-text: #fff7df;
+  --rsc-finalist-rank-bg: linear-gradient(135deg, rgba(209, 40, 143, 0.9), rgba(135, 53, 186, 0.86));
+  --rsc-finalist-link: #f9c7e4;
+  --rsc-finalist-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.05),
+    0 24px 54px rgba(6, 12, 31, 0.24);
   --rsc-guide-surface:
     radial-gradient(circle at top right, rgba(96, 165, 250, 0.12), transparent 32%),
     radial-gradient(circle at bottom left, rgba(209, 40, 143, 0.1), transparent 24%),
@@ -247,6 +262,101 @@
 #rabbita-scc-showcase .rsc-section-title--subtle {
   font-size: clamp(0.98rem, 1.4vw, 1.08rem);
   line-height: 1.68;
+}
+
+#rabbita-scc-showcase .rsc-finalist-board {
+  overflow: hidden;
+  padding: 1rem 1.2rem 0.3rem;
+  border: 1px solid var(--rsc-finalist-border);
+  border-radius: 30px;
+  background: var(--rsc-finalist-surface);
+  box-shadow: var(--rsc-finalist-shadow);
+}
+
+#rabbita-scc-showcase .rsc-finalist-head,
+#rabbita-scc-showcase .rsc-finalist-row {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.78fr) minmax(0, 1.22fr);
+  gap: 1rem;
+}
+
+#rabbita-scc-showcase .rsc-finalist-head {
+  padding: 0 0.2rem 0.9rem;
+  border-bottom: 1px solid var(--rsc-finalist-rule);
+}
+
+#rabbita-scc-showcase .rsc-finalist-head-cell {
+  color: var(--rsc-finalist-muted);
+  font-size: 0.88rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+#rabbita-scc-showcase .rsc-finalist-list {
+  display: grid;
+}
+
+#rabbita-scc-showcase .rsc-finalist-row {
+  align-items: start;
+  padding: 1rem 0.2rem;
+  border-bottom: 1px solid var(--rsc-finalist-rule);
+  transition: background 0.2s ease;
+}
+
+#rabbita-scc-showcase .rsc-finalist-row:last-child {
+  border-bottom: 0;
+}
+
+#rabbita-scc-showcase .rsc-finalist-project {
+  display: grid;
+  gap: 0.45rem;
+}
+
+#rabbita-scc-showcase .rsc-finalist-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+#rabbita-scc-showcase .rsc-finalist-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2rem;
+  min-height: 2rem;
+  padding: 0.2rem 0.45rem;
+  border-radius: 999px;
+  color: var(--rsc-finalist-rank-text);
+  font-size: 0.92rem;
+  font-weight: 800;
+  line-height: 1;
+  background: var(--rsc-finalist-rank-bg);
+  box-shadow: 0 10px 24px rgba(209, 40, 143, 0.22);
+}
+
+#rabbita-scc-showcase .rsc-finalist-title {
+  margin: 0.08rem 0 0;
+  color: var(--rsc-finalist-title);
+  font-size: 1.18rem;
+  line-height: 1.38;
+}
+
+#rabbita-scc-showcase .rsc-finalist-repo {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  color: var(--rsc-finalist-link);
+  font-size: 0.96rem;
+  line-height: 1.6;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+#rabbita-scc-showcase .rsc-finalist-desc {
+  margin: 0;
+  color: var(--rsc-finalist-text);
+  line-height: 1.8;
 }
 
 #rabbita-scc-showcase .rsc-grid {
@@ -579,6 +689,21 @@
     0 18px 38px rgba(0, 0, 0, 0.34);
   --rsc-signal-label: rgba(221, 229, 241, 0.78);
   --rsc-gridline: rgba(255, 255, 255, 0.02);
+  --rsc-finalist-surface:
+    radial-gradient(circle at top right, rgba(209, 40, 143, 0.16), transparent 26%),
+    radial-gradient(circle at bottom left, rgba(101, 79, 240, 0.12), transparent 26%),
+    linear-gradient(180deg, rgba(12, 17, 29, 0.99), rgba(7, 10, 18, 1));
+  --rsc-finalist-border: rgba(120, 136, 168, 0.18);
+  --rsc-finalist-rule: rgba(217, 228, 244, 0.1);
+  --rsc-finalist-title: #f6f8fd;
+  --rsc-finalist-text: rgba(229, 236, 246, 0.9);
+  --rsc-finalist-muted: rgba(183, 196, 218, 0.66);
+  --rsc-finalist-rank-text: #fff2d4;
+  --rsc-finalist-rank-bg: linear-gradient(135deg, rgba(224, 64, 176, 0.92), rgba(129, 76, 222, 0.86));
+  --rsc-finalist-link: #f3b7da;
+  --rsc-finalist-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 24px 56px rgba(0, 0, 0, 0.34);
   --rsc-guide-surface:
     radial-gradient(circle at top right, rgba(209, 40, 143, 0.14), transparent 24%),
     linear-gradient(180deg, rgba(14, 19, 30, 0.98), rgba(9, 13, 21, 1));
@@ -636,6 +761,10 @@
   box-shadow: 0 14px 30px rgba(0, 0, 0, 0.3);
 }
 
+[data-theme="dark"] #rabbita-scc-showcase .rsc-finalist-row:hover {
+  background: rgba(255, 255, 255, 0.015);
+}
+
 [data-theme="dark"] #rabbita-scc-showcase .rsc-section:last-of-type,
 [data-theme="dark"] #rabbita-scc-showcase .rsc-check-panel {
   backdrop-filter: blur(14px);
@@ -645,6 +774,11 @@
   #rabbita-scc-showcase .rsc-hero,
   #rabbita-scc-showcase .rsc-steps-grid {
     grid-template-columns: 1fr;
+  }
+
+  #rabbita-scc-showcase .rsc-finalist-head,
+  #rabbita-scc-showcase .rsc-finalist-row {
+    grid-template-columns: minmax(220px, 0.9fr) minmax(0, 1.1fr);
   }
 }
 
@@ -689,6 +823,25 @@
     grid-template-columns: 1fr;
   }
 
+  #rabbita-scc-showcase .rsc-finalist-board {
+    padding: 0.95rem 1rem 0.2rem;
+    border-radius: 24px;
+  }
+
+  #rabbita-scc-showcase .rsc-finalist-head {
+    display: none;
+  }
+
+  #rabbita-scc-showcase .rsc-finalist-row {
+    grid-template-columns: 1fr;
+    gap: 0.75rem;
+    padding: 0.95rem 0;
+  }
+
+  #rabbita-scc-showcase .rsc-finalist-title {
+    font-size: 1.08rem;
+  }
+
   #rabbita-scc-showcase .rsc-card-body,
   #rabbita-scc-showcase .rsc-step-card,
   #rabbita-scc-showcase .rsc-check-panel {
@@ -711,6 +864,21 @@
     border-radius: 20px;
   }
 
+  #rabbita-scc-showcase .rsc-finalist-board {
+    padding: 0.85rem 0.9rem 0.15rem;
+    border-radius: 20px;
+  }
+
+  #rabbita-scc-showcase .rsc-finalist-title-row {
+    gap: 0.6rem;
+  }
+
+  #rabbita-scc-showcase .rsc-finalist-rank {
+    min-width: 1.8rem;
+    min-height: 1.8rem;
+    font-size: 0.86rem;
+  }
+
   #rabbita-scc-showcase .rsc-hero-title {
     font-size: 1.9rem;
   }
@@ -731,6 +899,7 @@
   #rabbita-scc-showcase .rsc-section-title,
   #rabbita-scc-showcase .rsc-step-desc,
   #rabbita-scc-showcase .rsc-card-desc,
+  #rabbita-scc-showcase .rsc-finalist-desc,
   #rabbita-scc-showcase .rsc-highlight,
   #rabbita-scc-showcase .rsc-check-item {
     line-height: 1.62;


### PR DESCRIPTION
## What changed
- backfilled the missing repository links on the 2026 SCC showcase wall
- added a dedicated preliminary finalists section based on the organizer's published finalist poster
- added showcase-local language and light/dark switches for the English and Chinese pages
- fixed the showcase locale switch links so the pages build cleanly and preview correctly
- kept the hero count/date aligned with the current showcase roster

## Why
The showcase page needed two follow-up fixes after the initial roster update:
1. the newly announced finalist list needed to appear in a prominent position on the page
2. the local preview experience for the English and Chinese showcase pages was inconsistent, and the locale switch links could trigger broken-link/build issues

## Impact
Visitors can now see the officially announced preliminary finalists immediately, switch between English and Chinese directly on the showcase page, and preview both localized pages reliably from the built site.

## Validation
- ran `./node_modules/.bin/docusaurus build`
- verified local static preview routes for both `/2026-scc/showcase/` and `/zh/2026-scc/showcase/`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/moonbitlang/website/pull/35" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
