### PR TITLE
[codex] Fix Mooncakes login session handling

### DIFF
--- a/src/components/SignCla/index.tsx
+++ b/src/components/SignCla/index.tsx
@@ -17,8 +17,13 @@
 import styles from './index.module.css'
 import { useEffect, useState } from 'react'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
-import { jwtDecode } from 'jwt-decode'
 import BrowserOnly from '@docusaurus/BrowserOnly'
+import {
+  decodeMooncakesToken,
+  MOONCAKES_SESSION_STORAGE_KEY,
+  readMooncakesSession,
+  type MooncakesTokenPayload
+} from '@site/src/lib/mooncakesAuth'
 
 type SignState =
   | {
@@ -182,26 +187,51 @@ function ClientSignCla({ repo }: { repo: string }) {
   const [sign, setSign] = useState<SignState>({ signed: false })
   const mooncakesApi = customFields?.MOONCAKES_API as string
   const clientId = customFields?.GITHUB_OAUTH_CLIENT_ID as string
-  const accessToken = window.localStorage.getItem('access_token_with_time')
-  const accessTokenWithTime = accessToken
-    ? (JSON.parse(accessToken) as { access_token?: string; time: number })
-    : null
-  const signFailed =
-    accessTokenWithTime !== null && !accessTokenWithTime.access_token
-  const isSign =
-    accessTokenWithTime === null ||
-    signFailed ||
-    Date.now() - accessTokenWithTime.time > 90 * 24 * 60 * 60 * 1000
-  // Date.now() - accessTokenWithTime.time > 1000
+  const storedAccessToken = window.localStorage.getItem(
+    MOONCAKES_SESSION_STORAGE_KEY
+  )
+  const session = readMooncakesSession()
+  const payload =
+    session === null
+      ? null
+      : decodeMooncakesToken<MooncakesTokenPayload>(session.access_token)
+  const username =
+    payload !== null && typeof payload.username === 'string'
+      ? payload.username
+      : undefined
+  const githubUsername =
+    username !== undefined && typeof payload?.gh_avatar === 'string'
+      ? username
+      : undefined
+  const signFailed = storedAccessToken !== null && session === null
+  const isSign = session === null || githubUsername === undefined
   const redirectUrl = new URL(customFields?.HOST as string)
   redirectUrl.pathname = '/mooncakes/callback/github/cla'
   redirectUrl.searchParams.set('repo', repo)
 
-  if (isSign) {
+  useEffect(() => {
+    if (githubUsername === undefined) return
+    const checkIsSigned = async () => {
+      const params = new URLSearchParams()
+      params.set('gh_username', githubUsername)
+      params.set('repo', repo)
+      const res = await fetch(`${mooncakesApi}/cla/check_with_repo?${params}`, {
+        method: 'GET',
+        headers: {
+          accept: 'application/json'
+        }
+      })
+      const json = (await res.json()) as SignState
+      setSign(json)
+    }
+    checkIsSigned()
+  }, [githubUsername, mooncakesApi, repo])
+
+  if (isSign || session === null || githubUsername === undefined) {
     return (
       <div>
         {signFailed && <p>Sign in failed. Please try again.</p>}
-        <p>You must sign in to MoonBit to accept the CLA.</p>
+        <p>You must sign in with Github to accept the CLA.</p>
 
         <div className={styles['button-wrapper']}>
           <a
@@ -216,42 +246,17 @@ function ClientSignCla({ repo }: { repo: string }) {
       </div>
     )
   } else {
-    const { username } = jwtDecode<{ username: string }>(
-      accessTokenWithTime.access_token!
-    )
-    useEffect(() => {
-      const checkIsSigned = async () => {
-        const params = new URLSearchParams()
-        params.set('gh_username', username)
-        params.set('repo', repo)
-        const res = await fetch(
-          `${mooncakesApi}/cla/check_with_repo?${params}`,
-          {
-            method: 'GET',
-            headers: {
-              accept: 'application/json'
-            }
-          }
-        )
-        const json = (await res.json()) as SignState
-        setSign(json)
-      }
-      checkIsSigned()
-    }, [])
     return (
       <div>
         <p>
           Sign in as
-          <a href={`https://github.com/${username}`}>
+          <a href={`https://github.com/${githubUsername}`}>
             {' '}
-            <code>{username}</code>@github
+            <code>{githubUsername}</code>@github
           </a>
         </p>
         {!sign.signed ? (
-          <SignForm
-            accessToken={accessTokenWithTime.access_token}
-            repo={repo}
-          />
+          <SignForm accessToken={session.access_token} repo={repo} />
         ) : (
           <div>You have already signed at {sign.signed_time}</div>
         )}

--- a/src/lib/mooncakesAuth.ts
+++ b/src/lib/mooncakesAuth.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 International Digital Economy Academy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { jwtDecode } from 'jwt-decode'
+
+export const MOONCAKES_SESSION_STORAGE_KEY = 'access_token_with_time'
+const LEGACY_ACCESS_TOKEN_KEY = 'mooncakes-access-token'
+const LEGACY_USERNAME_KEY = 'mooncakes-username'
+const SESSION_TTL_MS = 90 * 24 * 60 * 60 * 1000
+
+export type MooncakesSession = {
+  access_token: string
+  time: number
+}
+
+export type MooncakesTokenPayload = {
+  username?: string
+  gh_avatar?: string | null
+  gh_name?: string | null
+}
+
+export type MooncakesUserSession = MooncakesSession & {
+  username: string
+  gh_avatar?: string | null
+  gh_name?: string | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+export function clearLegacyMooncakesSession(storage = window.localStorage) {
+  storage.removeItem(LEGACY_ACCESS_TOKEN_KEY)
+  storage.removeItem(LEGACY_USERNAME_KEY)
+}
+
+export function clearMooncakesSession(storage = window.localStorage) {
+  storage.removeItem(MOONCAKES_SESSION_STORAGE_KEY)
+  clearLegacyMooncakesSession(storage)
+}
+
+export function saveMooncakesSession(
+  accessToken: string,
+  storage = window.localStorage
+): MooncakesSession {
+  const session = {
+    access_token: accessToken,
+    time: Date.now()
+  }
+  storage.setItem(MOONCAKES_SESSION_STORAGE_KEY, JSON.stringify(session))
+  clearLegacyMooncakesSession(storage)
+  return session
+}
+
+export function readMooncakesSession(
+  storage = window.localStorage
+): MooncakesSession | null {
+  const raw = storage.getItem(MOONCAKES_SESSION_STORAGE_KEY)
+  if (raw === null) return null
+
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (
+      !isRecord(parsed) ||
+      typeof parsed.access_token !== 'string' ||
+      parsed.access_token === '' ||
+      typeof parsed.time !== 'number' ||
+      !Number.isFinite(parsed.time)
+    ) {
+      clearMooncakesSession(storage)
+      return null
+    }
+
+    if (Date.now() - parsed.time > SESSION_TTL_MS) {
+      clearMooncakesSession(storage)
+      return null
+    }
+
+    return {
+      access_token: parsed.access_token,
+      time: parsed.time
+    }
+  } catch {
+    clearMooncakesSession(storage)
+    return null
+  }
+}
+
+export function decodeMooncakesToken<T extends object>(
+  accessToken: string
+): T | null {
+  try {
+    return jwtDecode<T>(accessToken)
+  } catch {
+    return null
+  }
+}
+
+export function readMooncakesUserSession(
+  storage = window.localStorage
+): MooncakesUserSession | null {
+  const session = readMooncakesSession(storage)
+  if (session === null) return null
+
+  const payload = decodeMooncakesToken<MooncakesTokenPayload>(
+    session.access_token
+  )
+  if (payload === null || typeof payload.username !== 'string') {
+    clearMooncakesSession(storage)
+    return null
+  }
+
+  return {
+    ...session,
+    username: payload.username,
+    gh_avatar: payload.gh_avatar,
+    gh_name: payload.gh_name
+  }
+}
+
+export function getSafeRedirectPath(
+  search: string,
+  fallback = '/mooncakes'
+): string {
+  const redirect = new URLSearchParams(search).get('redirect')
+  if (redirect === null || redirect === '') return fallback
+
+  try {
+    const target = new URL(redirect, window.location.origin)
+    if (target.origin !== window.location.origin) return fallback
+    return `${target.pathname}${target.search}${target.hash}`
+  } catch {
+    return fallback
+  }
+}

--- a/src/pages/mooncakes/index.tsx
+++ b/src/pages/mooncakes/index.tsx
@@ -19,12 +19,13 @@ import Layout from '@theme/Layout'
 import clsx from 'clsx'
 import React, { useEffect, useState } from 'react'
 import styles from './index.module.css'
-import { jwtDecode } from 'jwt-decode'
+import { readMooncakesUserSession } from '@site/src/lib/mooncakesAuth'
 
 type UserInfo = {
   accessToken: string
   username: string
-  gh_avatar: string
+  gh_avatar?: string | null
+  gh_name?: string | null
 }
 
 function User(props: UserInfo): React.JSX.Element {
@@ -108,16 +109,15 @@ export default function Mooncakes(): React.JSX.Element {
   const clientId = customFields?.GITHUB_OAUTH_CLIENT_ID as string
 
   useEffect(() => {
-    const accessToken = localStorage.getItem('access_token_with_time')
-    const accessTokenWithTime = accessToken
-      ? (JSON.parse(accessToken) as { access_token: string; time: number })
-      : null
-    if (accessTokenWithTime === null) return
-    if (Date.now() - accessTokenWithTime.time > 90 * 24 * 60 * 60 * 1000) return
-    // if (Date.now() - accessTokenWithTime.time > 1000) return
+    const session = readMooncakesUserSession()
+    if (session === null) return
     setIsLogin(true)
-    const data = jwtDecode<UserInfo>(accessTokenWithTime.access_token)
-    setUserData({ ...data, accessToken: accessTokenWithTime.access_token })
+    setUserData({
+      accessToken: session.access_token,
+      username: session.username,
+      gh_avatar: session.gh_avatar,
+      gh_name: session.gh_name
+    })
   }, [])
   return (
     <Layout wrapperClassName={styles['main-wrapper']}>

--- a/src/pages/signin/index.module.css
+++ b/src/pages/signin/index.module.css
@@ -7,3 +7,10 @@
   flex-direction: column;
   gap: 1em;
 }
+
+.form-error {
+  font-weight: var(--ifm-font-weight-bold);
+  color: var(--ifm-color-danger-dark);
+  margin: 0;
+  font-size: 0.8em;
+}

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -24,13 +24,41 @@ import FormInput, {
 } from '@site/src/components/FormInput'
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
 import Link from '@docusaurus/Link'
+import {
+  getSafeRedirectPath,
+  saveMooncakesSession
+} from '@site/src/lib/mooncakesAuth'
 
 class LoginError extends Error {
-  detail: string
   constructor(detail: string) {
-    super()
-    this.detail = detail
+    super(detail)
   }
+}
+
+type LoginResponse = {
+  access_token: string
+}
+
+function isLoginResponse(value: unknown): value is LoginResponse {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'access_token' in value &&
+    typeof value.access_token === 'string' &&
+    value.access_token !== ''
+  )
+}
+
+async function getLoginErrorMessage(res: Response): Promise<string> {
+  try {
+    const json = (await res.json()) as { detail?: unknown }
+    if (typeof json.detail === 'string' && json.detail !== '') {
+      return json.detail
+    }
+  } catch {
+    // Fall through to the generic status message.
+  }
+  return `${res.status} ${res.statusText}`
 }
 
 function SignInForm() {
@@ -42,8 +70,9 @@ function SignInForm() {
   const [passwordError, setPasswordError] = useState<string | undefined>(
     undefined
   )
+  const [formError, setFormError] = useState<string | undefined>(undefined)
   const [signInEnable, setSignInEnable] = useState(true)
-  const signInMessage = 'Sign in'
+  const signInMessage = signInEnable ? 'Sign in' : 'Signing in...'
   const {
     siteConfig: { customFields }
   } = useDocusaurusContext()
@@ -61,6 +90,7 @@ function SignInForm() {
           onSubmit={async (e) => {
             e.preventDefault()
             if (!signInEnable) return
+            setFormError(undefined)
             let isValidate = true
             if (username === '') {
               setUsernameError('Required')
@@ -72,6 +102,7 @@ function SignInForm() {
             }
             if (!isValidate) return
             try {
+              setSignInEnable(false)
               const params = new URLSearchParams()
               params.set('username', username)
               params.set('password', password)
@@ -84,18 +115,23 @@ function SignInForm() {
                 body: params.toString()
               })
               if (!res.ok) {
-                if (res.status >= 400 && res.status < 500) {
-                  const json = (await res.json()) as { detail: string }
-                  throw new LoginError(json.detail)
-                }
-                throw new Error(`${res.status} ${res.statusText}`)
+                throw new LoginError(await getLoginErrorMessage(res))
               }
-              const json = (await res.json()) as { access_token: string }
-              localStorage.setItem('mooncakes-access-token', json.access_token)
-              localStorage.setItem('mooncakes-username', username)
+              const json = (await res.json()) as unknown
+              if (!isLoginResponse(json)) {
+                throw new LoginError('Sign in failed: missing access token')
+              }
+              saveMooncakesSession(json.access_token)
+              window.location.assign(
+                getSafeRedirectPath(window.location.search)
+              )
             } catch (e) {
               if (e instanceof LoginError) {
-                setPasswordError(e.detail)
+                setPasswordError(e.message)
+              } else if (e instanceof Error) {
+                setFormError(e.message)
+              } else {
+                setFormError('Failed to sign in')
               }
             } finally {
               setSignInEnable(true)
@@ -121,8 +157,12 @@ function SignInForm() {
             error={passwordError}
             setError={setPasswordError}
           />
+          {formError !== undefined && (
+            <p className={styles['form-error']}>{formError}</p>
+          )}
           <input
             type='submit'
+            disabled={!signInEnable}
             className={`button button--primary ${
               !signInEnable ? 'disabled' : ''
             }`}


### PR DESCRIPTION
## Summary
- Store password-login access tokens in the canonical `access_token_with_time` Mooncakes session format.
- Add shared session parsing/expiry helpers and use them from `/mooncakes` and CLA auth state.
- Keep CLA checks on GitHub-authenticated sessions so password-login tokens are not treated as GitHub identity.

## Root Cause
`/signin` stored successful password-login tokens under legacy keys (`mooncakes-access-token`, `mooncakes-username`) while the rest of the frontend reads `access_token_with_time`, so the backend login succeeded but the frontend login state never updated.

## Validation
- `moon check` in `src/pages/rabbita-home` passed with the existing deprecated `not(...)` warning.
- `pnpm exec prettier --check src/lib/mooncakesAuth.ts src/pages/signin/index.tsx src/pages/signin/index.module.css src/pages/mooncakes/index.tsx src/components/SignCla/index.tsx` passed.
- Local `/signin/` rendered in the in-app browser with no console errors.

## Known Existing Issue
- `pnpm typecheck` still fails on the pre-existing unrelated `plugins/rehype-moonbit-markdown/packages/shiki-lsif/src/lsif-db.ts:201` `MapIterator` error.