### PR TITLE
[codex] remove Intel macOS download checksum tab

### DIFF
--- a/src/pages/download/index.mdx
+++ b/src/pages/download/index.mdx
@@ -103,13 +103,6 @@ To download `.sha256` file using `curl` (or using `Invoke-WebRequest` on windows
   ```
 </TabItem>
 
-<TabItem value='mac-intel' label='Intel MacOS'>
-  ```bash
-  curl -O -L https://cli.moonbitlang.com/binaries/latest/moonbit-darwin-x86_64.sha256 # SHA checksums for binaries
-  curl -O -L https://cli.moonbitlang.com/binaries/latest/moonbit-darwin-x86_64.tar.gz.sha256 # SHA checksums for archive files
-  ```
-</TabItem>
-
 <TabItem value='ubuntu' label='x86-64 Ubuntu 20.04'>
   ```bash
   curl -O -L https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.sha256 # SHA checksums for binaries


### PR DESCRIPTION
## Summary

Remove the obsolete Intel macOS checksum tab from the English download page so it matches the current supported download surface and the localized Chinese page.

## Impact

Users no longer see checksum download commands for `moonbit-darwin-x86_64` on the download page.

## Validation

- `moon check` in `src/pages/rabbita-home` passed with 0 errors.
- Existing warning remains: `main/main.mbt:78` uses deprecated `not(...)` syntax.